### PR TITLE
Final Year Entry Option

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -39,6 +39,8 @@
     <div>
       <h2>GPA:</h2>
       <p id="gpa">not enough data</span>.</p>
+      <h3>Final Year Entry Student?:</h3>
+      <input id="fyEntryCheck" type="checkbox">
     </div>
   </section>
 

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -179,14 +179,17 @@ async function recalculate() {
     document.querySelector('#gpa').textContent = 'n/a';
     return;
   }
-
-  if (isAnyMarkUnder40(marks)) {
-    document.querySelector('#ruleA').textContent = 'n/a';
-    document.querySelector('#ruleB').textContent = 'n/a';
-    document.querySelector('#ruleC').textContent = 'n/a';
-    document.querySelector('#finalClassification').textContent = 'failed a module, no degree classification';
-    document.querySelector('#gpa').textContent = 'n/a';
-    return;
+  
+  const fyEntry = document.querySelector('#fyEntryCheck').checked;
+  if (!fyEntry) {
+    if (isAnyMarkUnder40(marks)) {
+      document.querySelector('#ruleA').textContent = 'n/a';
+      document.querySelector('#ruleB').textContent = 'n/a';
+      document.querySelector('#ruleC').textContent = 'n/a';
+      document.querySelector('#finalClassification').textContent = 'failed a module, no degree classification';
+      document.querySelector('#gpa').textContent = 'n/a';
+      return;
+    }
   }
 
   rules.prepareMarks(marks);

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -179,9 +179,7 @@ async function recalculate() {
     document.querySelector('#gpa').textContent = 'n/a';
     return;
   }
-  
-  const fyEntry = document.querySelector('#fyEntryCheck').checked;
-  if (!fyEntry) {
+
     if (isAnyMarkUnder40(marks)) {
       document.querySelector('#ruleA').textContent = 'n/a';
       document.querySelector('#ruleB').textContent = 'n/a';
@@ -190,7 +188,6 @@ async function recalculate() {
       document.querySelector('#gpa').textContent = 'n/a';
       return;
     }
-  }
 
   rules.prepareMarks(marks);
 
@@ -211,9 +208,15 @@ async function recalculate() {
 }
 
 function isAnyMarkUnder40(marks) {
+  const fyEntry = document.querySelector('#fyEntryCheck').checked;
+  if (!fyEntry) {
   return marks.fyp < 40 ||
     marks.l5.some(m => m < 40) ||
     marks.l6.some(m => m < 40);
+  } else {
+    return marks.fyp < 40 ||
+    marks.l6.some(m => m < 40);
+  }
 }
 
 async function gatherMarksFromPage() {

--- a/client/style.css
+++ b/client/style.css
@@ -199,18 +199,6 @@ ul {
   padding: 0;
 }
 
-
-
-/* .module :first-child {
-  flex-grow: 0;
-  margin-right: .5rem;
-} */
-
-/* .module span {
-  padding: 0.5ex 1ex;
-} */
-
-
 input {
   background: var(--bg);
   color: var(--fg);
@@ -242,11 +230,6 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
 }
 
-input:focus {
-  outline: 0.25rem var(--hibg) solid;
-}
-
-
 #finalClassification,
 #gpa,
 #rules span {
@@ -254,6 +237,11 @@ input:focus {
   font-weight: bold;
 }
 
+#fyEntryCheck {
+  display: block;
+  margin: 0 auto;
+  transform: scale(2);
+}
 
 .lock-button {
   background-image: url("./img/unlock-icon.png");


### PR DESCRIPTION
## Final Year Entry Student Option

This allows for the user to state that they entered at Final Year and so it calculates only using rule B relevant to Final Year Entry students.

This was referenced in [this issue](https://github.com/portsoc/dcalc/issues/58) and [this issue](https://github.com/portsoc/dcalc/issues/28).

This is done by changing the `isAnyMarkUnder40` check to only check if the marks in Final Year modules are below 40 when the checkbox is ticked.

I admit this may not be the best place for the checkbox on the page but that's easily changeable.
Also possible change:
> The user needs to update their marks after selecting the checkbox because the check is inside a function not a function on its own.


💻 [Project Issue](https://github.com/users/NikBit101/projects/1/views/1?pane=issue&itemId=25719681)