### PR TITLE
Final Year Entry Calculation Fix

### DIFF
--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -195,16 +195,25 @@ async function recalculate() {
   const b = rules.ruleB(marks);
   const c = rules.ruleC(marks);
 
+  const fyEntry = document.querySelector('#fyEntryCheck').checked;
+ 
   document.querySelector('#ruleA').textContent = a;
   document.querySelector('#ruleB').textContent = b;
   document.querySelector('#ruleC').textContent = c;
-
+  if (!fyEntry) {
   const finalMark = Math.max(a, b, c);
   const finalClassification = rules.toClassification(finalMark);
 
   document.querySelector('#finalClassification').textContent = finalClassification;
 
   document.querySelector('#gpa').textContent = rules.gpa(marks);
+  } else {
+   const finalMark = b;
+   const finalClassification = rules.toClassification(finalMark);
+   document.querySelector('#finalClassification').textContent = finalClassification;
+
+   document.querySelector('#gpa').textContent = rules.gpa(marks);
+  }
 }
 
 function isAnyMarkUnder40(marks) {


### PR DESCRIPTION
## Final Year Entry Calculation Fix

An oversight in my first implementation meant that, although it was ignoring first year grades if you had failed one and calculated your grade if you were a final year entry student. It now ignores them completely and just uses the only Final Year grade rule permissible which is Rule B.

Was a silly thing to miss in the first attempt but it's fixed now. This implementation may not be the best but it works well.
#18 Was the original PR.