### PR TITLE
Required marks and target grade

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -27,6 +27,16 @@
       <h2>Indication:</h2>
       <p id="finalClassification">not enough data</span>.</p>
       <p>This is the best result from Rules A, B and C.</p>
+      <div id="finalGradeDiv">
+        <label for="final-grade-input">Choose final grade:</label>
+        <select name="" id="final-grade-input">
+          <option value="First-class honours">First Class</option>
+          <option value="Second-class honours (upper division)">Second Class, Upper Division</option>
+          <option value="Second-class honours (lower division)">Second Class, Lower Division</option>
+          <option value="Third-class honours">Third Class</option>
+        </select>
+        <input type="button" id="targetGradeBtn" value="Go">
+      </div>
     </div>
     <div id=rules>
       <h2>Rules:</h2>
@@ -60,15 +70,7 @@
   </section>
 
   <section id="filterSection">
-    <div id="finalGradeDiv">
-      <label for="final-grade-input">Choose final grade:</label>
-      <select name="" id="final-grade-input">
-        <option value="first-class">First Class</option>
-        <option value="second-class-up">Second Class, Upper Division</option>
-        <option value="second-class-low">Second Class, Lower Division</option>
-        <option value="third-class">Third Class</option>
-      </select>
-    </div>
+
   </section>
 
   <section id="l5">

--- a/client/index.html
+++ b/client/index.html
@@ -169,7 +169,8 @@
       <input class="range-input" id="fyp" type="range" min="0" max="100" value="0">
     </ul>
     <div id="ClearButtonDiv">
-      <button id="ClearButton">Clear</button>
+      <button id="ClearButton">Clear All</button>
+      <button id="ClearButtonUnlocked">Clear Unlocked Modules</button>
     </div>
   </section>
 

--- a/client/index.html
+++ b/client/index.html
@@ -46,8 +46,8 @@
     <input id="fyEntryCheck" type="checkbox">
     </div>
     <div>
-    <p>Example Option Checkbox:</p>
-    <input id="" type="checkbox">
+    <p>Calculate Target Grade:</p>
+    <input id="targetGradeCheck" type="checkbox">
     </div>
     <div>
     <p>Example Option Checkbox:</p>
@@ -57,6 +57,18 @@
 
   <section id="showingShared" style="display: none">
     <h2>Showing shared marks. <a href="./">Edit my marks.</a></h2>
+  </section>
+
+  <section id="filterSection">
+    <div id="finalGradeDiv">
+      <label for="final-grade-input">Choose final grade:</label>
+      <select name="" id="final-grade-input">
+        <option value="first-class">First Class</option>
+        <option value="second-class-up">Second Class, Upper Division</option>
+        <option value="second-class-low">Second Class, Lower Division</option>
+        <option value="third-class">Third Class</option>
+      </select>
+    </div>
   </section>
 
   <section id="l5">

--- a/client/index.html
+++ b/client/index.html
@@ -25,17 +25,19 @@
   <section id="results">
     <div>
       <h2>Indication:</h2>
-      <p id="finalClassification">not enough data</span>.</p>
-      <p>This is the best result from Rules A, B and C.</p>
+      <div id="indicationDiv">
+        <p id="finalClassification">not enough data</span>.</p>
+        <p>This is the best result from Rules A, B and C.</p>
+      </div>
       <div id="finalGradeDiv">
-        <label for="final-grade-input">Choose final grade:</label>
+        <p for="final-grade-input" id="finalClassification">Choose final grade</p>
         <select name="" id="final-grade-input">
           <option value="First-class honours">First Class</option>
           <option value="Second-class honours (upper division)">Second Class, Upper Division</option>
           <option value="Second-class honours (lower division)">Second Class, Lower Division</option>
           <option value="Third-class honours">Third Class</option>
         </select>
-        <input type="button" id="targetGradeBtn" value="Go">
+        <button type="button" id="targetGradeBtn">Go</button>
       </div>
     </div>
     <div id=rules>

--- a/client/index.html
+++ b/client/index.html
@@ -169,7 +169,6 @@
       <input class="range-input" id="fyp" type="range" min="0" max="100" value="0">
     </ul>
     <div id="ClearButtonDiv">
-      <button id="ClearButton">Clear All</button>
       <button id="ClearButtonUnlocked">Clear Unlocked Modules</button>
     </div>
   </section>

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -74,6 +74,12 @@ function init() {
 
   /// END of button and slider section
 
+  const targetGradeBtn = document.getElementById("targetGradeBtn");
+  targetGradeBtn.addEventListener('click', () => {
+    calculateMarksByGrade()
+  })
+  
+
   const targetGradeCheck = document.getElementById("targetGradeCheck");
   const finalGradeDiv = document.getElementById("finalGradeDiv");
   finalGradeDiv.style.display = 'none'
@@ -169,7 +175,7 @@ async function loadModules() {
     const modules = data.split('\r\n');
     const modulesFinalYear = [];
     const modulesSecondYear = [];
-    debugger
+    // debugger
     for(const row of modules){
   
       const [name,year] = row.split(',');
@@ -374,6 +380,274 @@ function highlight(trigger, showHighlight) {
   for (const target of targets) {
     target.classList.toggle('highlight', showHighlight);
   }
+}
+
+function sum(array) {
+  let result = array.reduce(function(a, b){
+    return a + b;
+  });
+  return result
+}
+
+async function calculateMarksByGrade() {
+  console.log('works');
+  const retval = {
+    l5: [],
+    l6: [],
+    fyp: null,
+  };
+  recalculate()
+  // let marks = {
+  //   l5: [45, 56, 67, 78, 89, 90],
+  //   l6: [56, 67, 0, 0],
+  //   fyp: 68,
+  // }
+
+
+  // let retval = {
+  //   "l5": [
+  //       {
+  //           "disabled": true,
+  //           "mark": 68
+  //       },
+  //       {
+  //           "disabled": true,
+  //           "mark": 68
+  //       },
+  //       {
+  //           "disabled": true,
+  //           "mark": 67
+  //       },
+  //       {
+  //           "disabled": true,
+  //           "mark": 70
+  //       },
+  //       {
+  //           "disabled": true,
+  //           "mark": 72
+  //       },
+  //       {
+  //           "disabled": true,
+  //           "mark": 67
+  //       }
+  //   ],
+  //   "l6": [
+  //       {
+  //           "disabled": true,
+  //           "mark": 65
+  //       },
+  //       {
+  //           "disabled": true,
+  //           "mark": 69
+  //       },
+  //       {
+  //           "disabled": false,
+  //           "mark": 0
+  //       },
+  //       {
+  //           "disabled": false,
+  //           "mark": 0
+  //       }
+  //   ],
+  //   "fyp": {
+  //       "disabled": false,
+  //       "mark": 0
+  //   }
+  // }
+
+  /* for testing
+  
+
+  const marks = {
+      l5: [
+        {disabled: true,
+        mark: 50},
+        {disabled: false,
+        mark: 60}
+      ],
+      l6:  [
+        {disabled: true,
+        mark: 50},
+        {disabled: false,
+        mark: 60}
+      ],
+      fyp: {disabled: true,
+            mark: 50},
+  }
+  */
+  
+  const finalGradeSelect = document.getElementById('final-grade-input')
+  // if(finalGradeSelect.value === 'first-class'){
+  //   const minMark = 'test'
+  // }
+
+  const l5InputsRange = document.querySelectorAll('#l5 input[type="range"]');
+  for (const input of l5InputsRange) {
+    retval.l5.push({
+      disabled: input.hasAttribute('disabled'),
+      mark: Number(input.value)
+    });
+  }
+
+  // if (retval.l5.length !== 6) {
+  //   console.error('we do not have enough l5 inputs!');
+  // }
+
+  const l6InputsRange = document.querySelectorAll('#l6 input:not(#fyp)[type="range"]');
+  for (const input of l6InputsRange) {
+    retval.l6.push({
+      disabled: input.hasAttribute('disabled'),
+      mark: Number(input.value)
+    });
+  }
+  
+  const fypInputRange = document.querySelector('input[type="range"]#fyp');
+  retval.fyp = {
+    disabled: fypInputRange.hasAttribute('disabled'),
+    mark: Number(fypInputRange.value)
+  };
+
+  console.log(retval);
+  // reverse rule b (average)
+  // let sumResult = 0
+  // let minAvg = 70
+  // let count = 0
+  // marks.l6.forEach(item => {
+  //   if(item === 0){
+  //     count++
+  //   }
+  //   sumResult += item
+  // })
+  // const result = (2 * minAvg) - sumResult
+  // console.log(`count: ${count}`);
+  // console.log(`sum res: ${sumResult}`);
+  // console.log(`reverse res: ${result}`);
+  
+  
+
+  // if (retval.l6.length !== 4) {
+  //   console.error('we do not have enough l6 inputs!');
+  // }
+
+
+  // console.log(retval);
+
+  // const marks = {
+  //   l5: [],
+  //   l6: [],
+  //   fyp: null,
+  // }
+  // retval.l5.forEach(item => {
+  //   marks.l5.push(item.mark)
+  // })
+  // retval.l6.forEach(item => {
+  //   marks.l6.push(item.mark)
+  // })
+  // marks.fyp = (retval.fyp.mark)
+  // console.log(marks);
+
+  const l5InputsNumber = document.querySelectorAll('#l5 input[type="number"]');
+  const l6InputsNumber = document.querySelectorAll('#l6 input:not(#fyp)[type="number"]');
+  const fypInputNumber = document.querySelector('input[type="number"]#fyp')
+
+  let count = 0 // To control the loop if anything goes wrong
+  const minMark = 40
+  let finalClassification =  0 // undefined
+  while (finalClassification != finalGradeSelect.value) {
+    const marks = {
+      l5: [],
+      l6: [],
+      fyp: null,
+    }
+    
+    // retval.l5.map(obj => !obj.disabled? 20 : obj.mark)
+    // retval.l6.map(obj => !obj.disabled? 20 + 1 : obj.mark)
+    retval.l5.forEach(obj => {
+      if(!obj.disabled && obj.mark === 0) obj.mark = minMark
+      else if(!obj.disabled){
+        obj.mark += 0.4
+        obj.mark = Math.round(obj.mark)
+      }
+    })
+    retval.l6.forEach(obj => {
+      if(!obj.disabled && obj.mark === 0) obj.mark = minMark
+      else if(!obj.disabled){
+        obj.mark += 0.6
+        obj.mark = Math.round(obj.mark)
+      }
+    })
+    if(!retval.fyp.disabled && retval.fyp.mark === 0){
+      retval.fyp.mark = minMark
+    }
+    else if (!retval.fyp.disabled && retval.fyp.mark != 0){
+      retval.fyp.mark += 0.6
+      retval.fyp.mark = Math.round(retval.fyp.mark)
+
+    }
+    // if(!retval.fyp.disabled){
+      //   retval.fyp.mark += 1
+      // }
+      // console.log(retval);
+    retval.l5.forEach(item => {
+      marks.l5.push(item.mark)
+    })
+    retval.l6.forEach(item => {
+      marks.l6.push(item.mark)
+    })
+    marks.fyp = (retval.fyp.mark)
+
+    rules.prepareMarks(marks);
+    const a = rules.ruleA(marks);
+    const b = rules.ruleB(marks);
+    const c = rules.ruleC(marks);
+    const finalMark = Math.max(a, b, c);
+    finalClassification = rules.toClassification(finalMark);
+
+    if(count === 100) break
+    console.log(count);
+    console.log(marks);
+    console.log(finalClassification);
+    count++
+  }
+  // console.log(retval);
+
+  l5InputsNumber.forEach((input, index) => {
+    const currItem = retval.l5[index]
+    if(!input.hasAttribute('disabled')){
+      if(!currItem.disabled) {
+        input.value = currItem.mark
+      }
+    }
+  })
+  l5InputsRange.forEach((input, index) => {
+    const currItem = retval.l5[index]
+    if(!input.hasAttribute('disabled')){
+      if(!currItem.disabled) {
+        input.value = currItem.mark
+      }
+    }
+  })
+  l6InputsRange.forEach((input, index) => {
+    const currItem = retval.l6[index]
+    if(!input.hasAttribute('disabled')){
+      if(!currItem.disabled) {
+        input.value = currItem.mark
+      }
+    }
+  })
+  l6InputsNumber.forEach((input, index) => {
+    const currItem = retval.l6[index]
+    if(!input.hasAttribute('disabled')){
+      if(!currItem.disabled) {
+        input.value = currItem.mark
+      }
+    }
+  })
+  fypInputNumber.value = retval.fyp.mark
+  fypInputRange.value = retval.fyp.mark
+
+  recalculate()
+  
 }
 
 

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -33,6 +33,9 @@ function init() {
       if (!lockButtons[i].classList.contains('disabled')) {
         numberInputs[i].value = rangeSliders[i].value;
       }
+
+      document.querySelector('#targetGradeBtn').disabled = false ? true : false;
+
       rangeSliders[i].value = numberInputs[i].value;
     });
     
@@ -56,7 +59,7 @@ function init() {
       } else {
         module.value = ""; // clear values
       }
-
+      
       module.disabled = false; // reenables any inputs that were disabled - 1
     });
 
@@ -385,6 +388,7 @@ function highlight(trigger, showHighlight) {
 }
 
 async function calculateMarksByGrade() {
+
   const retval = {
     l5: [],
     l6: [],
@@ -544,7 +548,7 @@ async function calculateMarksByGrade() {
   fypInputRange.value = retval.fyp.mark
 
   recalculate()
-  
+  document.querySelector('#targetGradeBtn').disabled = true;
 }
 
 

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -81,14 +81,16 @@ function init() {
   
 
   const targetGradeCheck = document.getElementById("targetGradeCheck");
+  const indicationDiv = document.getElementById("indicationDiv")
   const finalGradeDiv = document.getElementById("finalGradeDiv");
   finalGradeDiv.style.display = 'none'
   targetGradeCheck.addEventListener('change', () => {
     if(targetGradeCheck.checked){
       finalGradeDiv.style.display = 'block'
+      indicationDiv.style.display = 'none'
     } else {
       finalGradeDiv.style.display = 'none'
-
+      indicationDiv.style.display = 'block'
     }
   })
 
@@ -382,104 +384,46 @@ function highlight(trigger, showHighlight) {
   }
 }
 
-function sum(array) {
-  let result = array.reduce(function(a, b){
-    return a + b;
-  });
-  return result
-}
-
 async function calculateMarksByGrade() {
-  console.log('works');
   const retval = {
     l5: [],
     l6: [],
     fyp: null,
   };
-  recalculate()
-  // let marks = {
-  //   l5: [45, 56, 67, 78, 89, 90],
-  //   l6: [56, 67, 0, 0],
-  //   fyp: 68,
-  // }
-
-
-  // let retval = {
-  //   "l5": [
-  //       {
-  //           "disabled": true,
-  //           "mark": 68
-  //       },
-  //       {
-  //           "disabled": true,
-  //           "mark": 68
-  //       },
-  //       {
-  //           "disabled": true,
-  //           "mark": 67
-  //       },
-  //       {
-  //           "disabled": true,
-  //           "mark": 70
-  //       },
-  //       {
-  //           "disabled": true,
-  //           "mark": 72
-  //       },
-  //       {
-  //           "disabled": true,
-  //           "mark": 67
-  //       }
-  //   ],
-  //   "l6": [
-  //       {
-  //           "disabled": true,
-  //           "mark": 65
-  //       },
-  //       {
-  //           "disabled": true,
-  //           "mark": 69
-  //       },
-  //       {
-  //           "disabled": false,
-  //           "mark": 0
-  //       },
-  //       {
-  //           "disabled": false,
-  //           "mark": 0
-  //       }
-  //   ],
-  //   "fyp": {
-  //       "disabled": false,
-  //       "mark": 0
-  //   }
-  // }
 
   /* for testing
   
+    let retval = {
+    "l5": [
+        {"disabled": true,
+         "mark": 68},
+        {"disabled": true,
+         "mark": 68},
+        {"disabled": true,
+         "mark": 67},
+        {"disabled": true,
+         "mark": 70},
+        {"disabled": true,
+         "mark": 72},
+        {"disabled": true,
+         "mark": 67}],
+    "l6": [
+        {"disabled": true,
+         "mark": 65},
+        {"disabled": true,
+         "mark": 69},
+        {"disabled": false,
+         "mark": 0},
+        {"disabled": false,
+         "mark": 0}],
+    "fyp": {"disabled": false,
+            "mark": 0}
+          }
 
-  const marks = {
-      l5: [
-        {disabled: true,
-        mark: 50},
-        {disabled: false,
-        mark: 60}
-      ],
-      l6:  [
-        {disabled: true,
-        mark: 50},
-        {disabled: false,
-        mark: 60}
-      ],
-      fyp: {disabled: true,
-            mark: 50},
   }
   */
   
   const finalGradeSelect = document.getElementById('final-grade-input')
-  // if(finalGradeSelect.value === 'first-class'){
-  //   const minMark = 'test'
-  // }
 
   const l5InputsRange = document.querySelectorAll('#l5 input[type="range"]');
   for (const input of l5InputsRange) {
@@ -488,10 +432,6 @@ async function calculateMarksByGrade() {
       mark: Number(input.value)
     });
   }
-
-  // if (retval.l5.length !== 6) {
-  //   console.error('we do not have enough l5 inputs!');
-  // }
 
   const l6InputsRange = document.querySelectorAll('#l6 input:not(#fyp)[type="range"]');
   for (const input of l6InputsRange) {
@@ -507,61 +447,20 @@ async function calculateMarksByGrade() {
     mark: Number(fypInputRange.value)
   };
 
-  console.log(retval);
-  // reverse rule b (average)
-  // let sumResult = 0
-  // let minAvg = 70
-  // let count = 0
-  // marks.l6.forEach(item => {
-  //   if(item === 0){
-  //     count++
-  //   }
-  //   sumResult += item
-  // })
-  // const result = (2 * minAvg) - sumResult
-  // console.log(`count: ${count}`);
-  // console.log(`sum res: ${sumResult}`);
-  // console.log(`reverse res: ${result}`);
-  
-  
-
-  // if (retval.l6.length !== 4) {
-  //   console.error('we do not have enough l6 inputs!');
-  // }
-
-
-  // console.log(retval);
-
-  // const marks = {
-  //   l5: [],
-  //   l6: [],
-  //   fyp: null,
-  // }
-  // retval.l5.forEach(item => {
-  //   marks.l5.push(item.mark)
-  // })
-  // retval.l6.forEach(item => {
-  //   marks.l6.push(item.mark)
-  // })
-  // marks.fyp = (retval.fyp.mark)
-  // console.log(marks);
-
   const l5InputsNumber = document.querySelectorAll('#l5 input[type="number"]');
   const l6InputsNumber = document.querySelectorAll('#l6 input:not(#fyp)[type="number"]');
   const fypInputNumber = document.querySelector('input[type="number"]#fyp')
 
   let count = 0 // To control the loop if anything goes wrong
   const minMark = 40
-  let finalClassification =  0 // undefined
+  let finalClassification = undefined // undefined
   while (finalClassification != finalGradeSelect.value) {
     const marks = {
       l5: [],
       l6: [],
       fyp: null,
     }
-    
-    // retval.l5.map(obj => !obj.disabled? 20 : obj.mark)
-    // retval.l6.map(obj => !obj.disabled? 20 + 1 : obj.mark)
+
     retval.l5.forEach(obj => {
       if(!obj.disabled && obj.mark === 0) obj.mark = minMark
       else if(!obj.disabled){
@@ -584,10 +483,7 @@ async function calculateMarksByGrade() {
       retval.fyp.mark = Math.round(retval.fyp.mark)
 
     }
-    // if(!retval.fyp.disabled){
-      //   retval.fyp.mark += 1
-      // }
-      // console.log(retval);
+
     retval.l5.forEach(item => {
       marks.l5.push(item.mark)
     })
@@ -602,14 +498,15 @@ async function calculateMarksByGrade() {
     const c = rules.ruleC(marks);
     const finalMark = Math.max(a, b, c);
     finalClassification = rules.toClassification(finalMark);
+    
+    const allMarks = marks.l5.concat(marks.prepared.l6)
+    for (const i of allMarks){
+      if (i > 100) return;
+    }
 
-    if(count === 100) break
-    console.log(count);
-    console.log(marks);
-    console.log(finalClassification);
+    if(count === 100) break // To prevent infinite loop
     count++
   }
-  // console.log(retval);
 
   l5InputsNumber.forEach((input, index) => {
     const currItem = retval.l5[index]
@@ -645,8 +542,6 @@ async function calculateMarksByGrade() {
   })
   fypInputNumber.value = retval.fyp.mark
   fypInputRange.value = retval.fyp.mark
-
-  recalculate()
   
 }
 

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -27,6 +27,7 @@ function init() {
   const numberInputs = document.querySelectorAll('input[type="number"]');
   const lockButtons = document.querySelectorAll('.lock-button');
   const clearButton = document.querySelector('#ClearButton');
+  const clearUnlockedButton = document.querySelector('#ClearButtonUnlocked')
 
   for (let i = 0; i < rangeSliders.length; i++) {
     rangeSliders[i].addEventListener('input', () => {
@@ -73,6 +74,13 @@ function init() {
       slider.disabled = false; // 3
     });
   });
+
+  clearUnlockedButton.addEventListener('click', () => {
+    const allInputs = Object.values(document.querySelectorAll('#l5 input, #l6 input'));
+    allInputs.filter(input => !input.hasAttribute('disabled') && input.type != 'text').forEach(eachInput => {
+      eachInput.value = 0
+    })
+  })
 
 
   /// END of button and slider section

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -26,8 +26,7 @@ function init() {
   const rangeSliders = document.querySelectorAll('input[type="range"]');
   const numberInputs = document.querySelectorAll('input[type="number"]');
   const lockButtons = document.querySelectorAll('.lock-button');
-  const clearButton = document.querySelector('#ClearButton');
-  const clearUnlockedButton = document.querySelector('#ClearButtonUnlocked')
+  const clearUnlockedButton = document.querySelector('#ClearButtonUnlocked');
 
   for (let i = 0; i < rangeSliders.length; i++) {
     rangeSliders[i].addEventListener('input', () => {
@@ -50,30 +49,6 @@ function init() {
       numberInputs[i].disabled = !numberInputs[i].disabled;
     });
   }
-
-  // upon pressing the "clear" button
-  clearButton.addEventListener('click', () => {
-    const modules = document.querySelectorAll('input');
-    modules.forEach(module => {
-      if (module.type === 'checkbox') {
-        module.checked = false; // uncheck any checkboxes
-      } else {
-        module.value = ""; // clear values
-      }
-      
-      module.disabled = false; // reenables any inputs that were disabled - 1
-    });
-
-    numberInputs.forEach(number => {
-      number.value = 0;
-      number.disabled = false; // 2
-    });
-
-    rangeSliders.forEach(slider => {
-      slider.value = 0;
-      slider.disabled = false; // 3
-    });
-  });
 
   clearUnlockedButton.addEventListener('click', () => {
     const allInputs = Object.values(document.querySelectorAll('#l5 input, #l6 input'));

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -507,7 +507,7 @@ async function calculateMarksByGrade() {
     if(count === 100) break // To prevent infinite loop
     count++
   }
-
+  console.log(finalClassification);
   l5InputsNumber.forEach((input, index) => {
     const currItem = retval.l5[index]
     if(!input.hasAttribute('disabled')){
@@ -542,6 +542,8 @@ async function calculateMarksByGrade() {
   })
   fypInputNumber.value = retval.fyp.mark
   fypInputRange.value = retval.fyp.mark
+
+  recalculate()
   
 }
 

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -74,6 +74,18 @@ function init() {
 
   /// END of button and slider section
 
+  const targetGradeCheck = document.getElementById("targetGradeCheck");
+  const finalGradeDiv = document.getElementById("finalGradeDiv");
+  finalGradeDiv.style.display = 'none'
+  targetGradeCheck.addEventListener('change', () => {
+    if(targetGradeCheck.checked){
+      finalGradeDiv.style.display = 'block'
+    } else {
+      finalGradeDiv.style.display = 'none'
+
+    }
+  })
+
   const fyEntryCheck = document.getElementById("fyEntryCheck");
   fyEntryCheck.addEventListener('change', () => {
     const sectionL5 = document.getElementById("l5");

--- a/client/js/ui.js
+++ b/client/js/ui.js
@@ -80,6 +80,7 @@ function init() {
     allInputs.filter(input => !input.hasAttribute('disabled') && input.type != 'text').forEach(eachInput => {
       eachInput.value = 0
     })
+    document.querySelector('#targetGradeBtn').disabled = false ? true : false;
   })
 
 

--- a/client/style.css
+++ b/client/style.css
@@ -336,8 +336,8 @@ adapted from: https://uiverse.io/e-coders/nervous-chipmunk-49
   align-items: center;
 }
 
-#ClearButton,
-#copy {
+#copy,
+#ClearButtonUnlocked {
   background-color: #FAFBFC;
   border: 1px solid rgba(27, 31, 35, 0.15);
   border-radius: 6px;
@@ -351,25 +351,28 @@ adapted from: https://uiverse.io/e-coders/nervous-chipmunk-49
   touch-action: manipulation;
   vertical-align: middle;
  }
- 
- #ClearButton:hover {
+
+ #copy,
+ #ClearButtonUnlocked:hover {
   background-color: #F3F4F6;
   transition-duration: 0.1s;
  }
  
- #ClearButton:disabled {
+ #ClearButtonUnlocked:disabled {
   background-color: #FAFBFC;
   border-color: rgba(27, 31, 35, 0.15);
   color: #959DA5;
   cursor: default;
  }
  
- #ClearButton:active {
+ #copy,
+ #ClearButtonUnlocked:active {
   background-color: #EDEFF2;
   box-shadow: rgba(225, 228, 232, 0.2) 0 1px 0 inset;
  }
  
- #ClearButton:focus {
+ #copy,
+ #ClearButtonUnlocked:focus {
   outline: 1px transparent;
  }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "type": "module",
   "scripts": {
-    "start": "npm install && node server.js"
+    "start": "npm install && set OPENSSL_CONF=./config/openssl.cnf && node server.js"
   },
   "name": "dcalc_ext",
   "description": "University of Portsmouth calculates final degree classification in three ways, and has recently added the Grade Point Average (GPA) to graduate's transcripts.  This app _indicates_ how module marks can combine to form a final degree classification, it also calculates an incicative GPA.",


### PR DESCRIPTION
# Implementation of required marks for a target grade

- Implemented a function to show required marks to get a target grade (first class, second class)
- Added a select box and a button in '**Indication**' section
- Added a checkbox called '**Calculate Target Grade**'

## Testing

1. type `npm start`
2. Click '**Clear**' button
3. Put desired module marks for second year
4. **Lock** all the second year modules
5. Leave the final year modules at 0
6. Check '**Calculate Target Grade**'
7. Choose Grade and Click '**Go**'.

## Important

- Do not choose 'third class' if the marks seem to be above third class because it will **_not work_**.
- Do not forget to **_lock_** the modules otherwise it will **_change_**.

## Some Bugs

- For example, first-class is target grade. The required mark shows 70 in 5 modules. But you can slide down up to 68 on module sliders and still shows first class. (This is fine though)
- You can slide all the way down to 40 on one final year module and still shows first class.
